### PR TITLE
Implement "Coin Locking" mechanics

### DIFF
--- a/sources/chirp.move
+++ b/sources/chirp.move
@@ -371,6 +371,49 @@ module blhnsuicntrtctkn::chirp {
         treasury.unblock_minting();
     }
 
+    #[allow(lint(self_transfer))]
+    /// Locks coins in the depository for recipients to claim later.
+    ///
+    /// This function deposits coins into a recipient's account, merging them 
+    /// with existing coins. Deposited coins can only be fully claimed after a
+    /// set time. If a user tries to claim locked coins early, a fine will be
+    /// applied, and unclaimed coins will go to the liquidity pool.
+    ///
+    /// ## Parameters:
+    /// - `vault`: Mutable reference to the Vault managing the depository.
+    /// - `coins`: Vector of coins to lock.
+    /// - `recipients`: Vector of recipients to lock coins for.
+    /// - `amounts`: Vector of amounts to lock for each recipient.
+    ///
+    /// ## Errors
+    /// - `EWrongVersion`: If the vault version does not match the VAULT_VERSION.
+    public fun lock_batch(
+        vault: &mut Vault,
+        mut coins: vector<Coin<CHIRP>>,
+        mut recipients: vector<address>,
+        mut amounts: vector<u64>,
+        ctx: &mut TxContext,
+    ) {
+        assert!(vault.version == VAULT_VERSION, EWrongVersion);
+
+        let mut all_coins = coins.pop_back();
+        pay::join_vec(&mut all_coins, coins);
+
+        while(!recipients.is_empty()) {
+            let recipient: address = recipients.pop_back();
+            let amount: u64 = amounts.pop_back();
+            let coin: Coin<CHIRP> = all_coins.split(amount, ctx);
+            let depository: &mut ObjectTable<address, Coin<CHIRP>> = vault.depository();
+            if (!depository.contains(recipient)) {
+                depository.add(recipient, coin)
+            } else {
+                depository[recipient].join(coin)
+            }
+        };
+        recipients.destroy_empty();
+        transfer::public_transfer(all_coins, ctx.sender());
+    }
+
     // === Private Functions ===
 
     /// Returns the treasury from the vault.
@@ -699,6 +742,54 @@ module blhnsuicntrtctkn::chirp_tests {
         {
             assert_eq_chirp_coin(@0x111, 1000, &scenario);
             assert_eq_chirp_coin(@0x222, 2000, &scenario);
+            assert_eq_chirp_coin(@0x333, 3000, &scenario);
+            assert_eq_chirp_coin(PUBLISHER, 9000, &scenario);
+        };
+        scenario.end();
+    }
+
+    #[test]
+    fun test_lock_batch_allows_to_lock_claimable_rewards()
+    {
+        let mut scenario = test_scenario::begin(PUBLISHER);
+        {
+            chirp::init_for_testing(scenario.ctx());
+            clock::share_for_testing(clock::create_for_testing(scenario.ctx()));
+        };
+        scenario.next_tx(PUBLISHER);
+        {
+            let mut vault: Vault = scenario.take_shared();
+            let wallets = vector[@0x111, @0x222, @0x333];
+            let coins = vector[
+                coin::mint_for_testing<CHIRP>(5000, scenario.ctx()),
+                coin::mint_for_testing<CHIRP>(5000, scenario.ctx()),
+                coin::mint_for_testing<CHIRP>(5000, scenario.ctx()),
+            ];
+            chirp::lock_batch(&mut vault, coins, wallets, vector[1000, 2000, 3000], scenario.ctx());
+            test_scenario::return_shared(vault);
+        };
+        scenario.next_tx(@0x111);
+        {
+            let mut vault: Vault = scenario.take_shared();
+            chirp::claim(&mut vault, 1000, scenario.ctx());
+            test_scenario::return_shared(vault);
+        };
+        scenario.next_tx(@0x222);
+        {
+            let mut vault: Vault = scenario.take_shared();
+            chirp::claim(&mut vault, 2000, scenario.ctx());
+            test_scenario::return_shared(vault);
+        };
+        scenario.next_tx(@0x333);
+        {
+            let mut vault: Vault = scenario.take_shared();
+            chirp::claim(&mut vault, 3000, scenario.ctx());
+            test_scenario::return_shared(vault);
+        };
+        scenario.next_tx(PUBLISHER);
+        {
+            assert_eq_chirp_coin(@0x111, 1000, &scenario);
+            assert_eq_chirp_coin(@0x221, 2000, &scenario);
             assert_eq_chirp_coin(@0x333, 3000, &scenario);
             assert_eq_chirp_coin(PUBLISHER, 9000, &scenario);
         };

--- a/sources/chirp.move
+++ b/sources/chirp.move
@@ -49,9 +49,9 @@ module blhnsuicntrtctkn::chirp {
     /// Coin icon
     const COIN_ICON: vector<u8> = b"https://download.chirpwireless.io/images/CHIRP_White_OBG.svg";
     /// Default vesting period.
-    const VESTING_PERIOD: u64 = 10;
+    const VESTING_PERIOD: u64 = 45;
     /// Default initial penalty.
-    const INITIAL_PENALTY: u64 = 9_000_000_000;
+    const INITIAL_PENALTY: u64 = 6_000_000_000;
     /// Current version of the vault.
     const VAULT_VERSION: u64 = 2;
     /// Pool dispatcher component name
@@ -910,8 +910,13 @@ module blhnsuicntrtctkn::chirp_tests {
         scenario.next_tx(PUBLISHER);
         {
             let mut vault: Vault = scenario.take_shared();
+            let vcap: VestingAdminCap = test_scenario::take_from_sender(&scenario);
+            chirp::set_vesting_penalty(&vcap, &mut vault, 9_000_000_000);
+
             let coins = vector[coin::mint_for_testing<CHIRP>(1000, scenario.ctx())];
             chirp::lock_batch(&mut vault, coins, vector[USER], vector[1000], scenario.ctx());
+
+            test_scenario::return_to_sender(&scenario, vcap);
             test_scenario::return_shared(vault);
         };
         scenario.next_tx(USER);
@@ -934,12 +939,13 @@ module blhnsuicntrtctkn::chirp_tests {
         scenario.next_tx(PUBLISHER);
         {
             let mut vault: Vault = scenario.take_shared();
-            let cap: ScheduleAdminCap = test_scenario::take_from_sender(&scenario);
+            let vcap: VestingAdminCap = test_scenario::take_from_sender(&scenario);
+            chirp::set_vesting_penalty(&vcap, &mut vault, 9_000_000_000);
 
             let coins = vector[coin::mint_for_testing<CHIRP>(1000, scenario.ctx())];
             chirp::lock_batch(&mut vault, coins, vector[USER], vector[1000], scenario.ctx());
 
-            test_scenario::return_to_sender(&scenario, cap);
+            test_scenario::return_to_sender(&scenario, vcap);
             test_scenario::return_shared(vault);
         };
         scenario.next_tx(USER);
@@ -968,7 +974,8 @@ module blhnsuicntrtctkn::chirp_tests {
         scenario.next_tx(PUBLISHER);
         {
             let mut vault: Vault = scenario.take_shared();
-            let cap: ScheduleAdminCap = test_scenario::take_from_sender(&scenario);
+            let vcap: VestingAdminCap = test_scenario::take_from_sender(&scenario);
+            chirp::set_vesting_penalty(&vcap, &mut vault, 9_000_000_000);
 
             // Depositing 1000 and locking 1000 coins
             let coins = vector[coin::mint_for_testing<CHIRP>(1000, scenario.ctx())];
@@ -976,7 +983,7 @@ module blhnsuicntrtctkn::chirp_tests {
             let coins = vector[coin::mint_for_testing<CHIRP>(1000, scenario.ctx())];
             chirp::deposit_batch(&mut vault, coins, vector[USER], vector[1000], scenario.ctx());
 
-            test_scenario::return_to_sender(&scenario, cap);
+            test_scenario::return_to_sender(&scenario, vcap);
             test_scenario::return_shared(vault);
         };
         scenario.next_tx(USER);
@@ -1004,7 +1011,8 @@ module blhnsuicntrtctkn::chirp_tests {
         scenario.next_tx(PUBLISHER);
         {
             let mut vault: Vault = scenario.take_shared();
-            let cap: ScheduleAdminCap = test_scenario::take_from_sender(&scenario);
+            let vcap: VestingAdminCap = test_scenario::take_from_sender(&scenario);
+            chirp::set_vesting_penalty(&vcap, &mut vault, 9_000_000_000);
 
             // Depositing 1000 and locking 1000 coins
             let coins = vector[coin::mint_for_testing<CHIRP>(1000, scenario.ctx())];
@@ -1012,7 +1020,7 @@ module blhnsuicntrtctkn::chirp_tests {
             let coins = vector[coin::mint_for_testing<CHIRP>(1000, scenario.ctx())];
             chirp::deposit_batch(&mut vault, coins, vector[USER], vector[1000], scenario.ctx());
 
-            test_scenario::return_to_sender(&scenario, cap);
+            test_scenario::return_to_sender(&scenario, vcap);
             test_scenario::return_shared(vault);
         };
         scenario.next_tx(USER);
@@ -1054,7 +1062,9 @@ module blhnsuicntrtctkn::chirp_tests {
         {
             let mut vault: Vault = scenario.take_shared();
             let vest_cap: VestingAdminCap = test_scenario::take_from_sender(&scenario);
+            chirp::set_vesting_penalty(&vest_cap, &mut vault, 9_000_000_000);
             chirp::set_vesting_period(&vest_cap, &mut vault, 20);
+
             let sched_cap: ScheduleAdminCap = test_scenario::take_from_sender(&scenario);
             chirp::unblock_minting(&sched_cap, &mut vault);
             test_scenario::return_shared(vault);

--- a/sources/chirp.move
+++ b/sources/chirp.move
@@ -1081,7 +1081,7 @@ module blhnsuicntrtctkn::chirp_tests {
         {
             let mut vault: Vault = scenario.take_shared();
             assert_eq_chirp_coin(USER, 50, &scenario);
-            assert_pool_eq_chirp_coin(&mut vault, b"lockup".to_string(), 950, &scenario);
+            assert_pool_eq_chirp_coin(&mut vault, b"lockup".to_string(), 450, &scenario);
             test_scenario::return_shared(vault);
         };
         scenario.end();

--- a/sources/chirp.move
+++ b/sources/chirp.move
@@ -15,6 +15,7 @@ module blhnsuicntrtctkn::chirp {
     use blhnsuicntrtctkn::schedule::{Self};
     use blhnsuicntrtctkn::treasury::{Self, Treasury};
     use std::string::{String};
+    use std::u64::{Self};
     use sui::clock::{Clock};
     use sui::coin::{Self, Coin};
     use sui::object_bag::{Self, ObjectBag};
@@ -32,8 +33,6 @@ module blhnsuicntrtctkn::chirp {
     const EWrongVersion: u64 = 2;
     /// Error code used when an invalid pool is used in the schedule.
     const EInvalidPool: u64 = 3;
-    /// Error code used when a user tries to claim more coins than they have.
-    const ENotEnoughFunds: u64 = 4;
 
     // === Constants ===
     /// Maximum supply of CHIRP tokens.
@@ -51,6 +50,8 @@ module blhnsuicntrtctkn::chirp {
     const COIN_ICON: vector<u8> = b"https://download.chirpwireless.io/images/CHIRP_White_OBG.svg";
     /// Default vesting period.
     const VESTING_PERIOD: u64 = 10;
+    /// Default initial penalty.
+    const INITIAL_PENALTY: u64 = 9_000_000_000;
     /// Current version of the vault.
     const VAULT_VERSION: u64 = 2;
     /// Pool dispatcher component name
@@ -128,7 +129,7 @@ module blhnsuicntrtctkn::chirp {
         vault.registry.add(POOL_DISPATCHER.to_string(), pool_dispatcher::default(ctx));
         vault.registry.add(TREASURY.to_string(), treasury::create(treasury_cap, COIN_MAX_SUPPLY, schedule::default(), ctx));
         vault.registry.add(DEPOSITORY.to_string(), object_table::new<address, Coin<CHIRP>>(ctx));
-        vault.registry.add(VESTING_LEDGER.to_string(), vesting_ledger::create(VESTING_PERIOD, ctx));
+        vault.registry.add(VESTING_LEDGER.to_string(), vesting_ledger::create<CHIRP>(VESTING_PERIOD, INITIAL_PENALTY, ctx));
 
         vault.premint(ctx);
 
@@ -167,8 +168,7 @@ module blhnsuicntrtctkn::chirp {
             };
             pools.destroy_empty();
             coins.destroy_empty();
-        };
-        vault.vesting_ledger().advance_epoch();
+        }
     }
 
     /// Replaces a schedule entry in the `Vault` of CHIRP tokens.
@@ -319,16 +319,29 @@ module blhnsuicntrtctkn::chirp {
     /// - `EWrongVersion`: If the vault version does not match the VAULT_VERSION.
     entry fun claim(vault: &mut Vault, amount: u64, ctx: &mut TxContext) {
         assert!(vault.version == VAULT_VERSION, EWrongVersion);
-        let ledger: &mut VestingLedger = vault.vesting_ledger();
-        assert!(ledger.available_balance(ctx.sender()) >= amount, ENotEnoughFunds);
-        let penalty_amount = ledger.claim(ctx.sender(), amount);
-        if (penalty_amount > 0) {
-            let total = &mut vault.depository()[ctx.sender()];
-            let penalty = total.split(penalty_amount, ctx);
-            vault.pool_dispatcher().transfer(b"lockup".to_string(), penalty);
+
+        let depository = vault.depository();
+        let sender = ctx.sender();
+
+        let mut claimed_coins = if (depository.contains(sender)) {
+            let total_deposit = &mut depository[sender];
+            let claimable_amount = u64::min(amount, total_deposit.value());
+            total_deposit.split(claimable_amount, ctx)
+        } else {
+            coin::zero<CHIRP>(ctx)
         };
-        let total = &mut vault.depository()[ctx.sender()];
-        transfer::public_transfer(total.split(amount, ctx), ctx.sender());
+
+        let remaining_amount = amount - claimed_coins.value();
+        if (remaining_amount > 0 ) {
+            let current_epoch = vault.treasury().current_epoch();
+
+            let vesting_ledger = vault.vesting_ledger();
+            let (locked_coins, penalty) = vesting_ledger.claim(sender, remaining_amount, current_epoch, ctx);
+
+            vault.pool_dispatcher().transfer(b"lockup".to_string(), penalty);
+            claimed_coins.join(locked_coins);
+        };
+        transfer::public_transfer(claimed_coins, sender);
     }
 
     #[allow(lint(self_transfer))]
@@ -367,8 +380,7 @@ module blhnsuicntrtctkn::chirp {
                 depository.add(recipient, coin)
             } else {
                 depository[recipient].join(coin)
-            };
-            vault.vesting_ledger().deposit(recipient, amount, ctx);
+            }
         };
         recipients.destroy_empty();
         transfer::public_transfer(all_coins, ctx.sender());
@@ -420,6 +432,8 @@ module blhnsuicntrtctkn::chirp {
     ) {
         assert!(vault.version == VAULT_VERSION, EWrongVersion);
 
+        let current_epoch = vault.treasury().current_epoch();
+
         let mut all_coins = coins.pop_back();
         pay::join_vec(&mut all_coins, coins);
 
@@ -427,13 +441,7 @@ module blhnsuicntrtctkn::chirp {
             let recipient: address = recipients.pop_back();
             let amount: u64 = amounts.pop_back();
             let coin: Coin<CHIRP> = all_coins.split(amount, ctx);
-            let depository: &mut ObjectTable<address, Coin<CHIRP>> = vault.depository();
-            if (!depository.contains(recipient)) {
-                depository.add(recipient, coin)
-            } else {
-                depository[recipient].join(coin)
-            };
-            vault.vesting_ledger().lock(recipient, amount, ctx);
+            vault.vesting_ledger().lock(recipient, coin, current_epoch, ctx);
         };
         recipients.destroy_empty();
         transfer::public_transfer(all_coins, ctx.sender());
@@ -459,8 +467,19 @@ module blhnsuicntrtctkn::chirp {
     ) {
         assert!(vault.version == VAULT_VERSION, EWrongVersion);
 
-        let ledger: &mut VestingLedger = vault.vesting_ledger();
+        let ledger: &mut VestingLedger<CHIRP> = vault.vesting_ledger();
         ledger.set_vesting_period(period);
+    }
+
+    public fun set_vesting_penalty(
+        _: &VestingAdminCap,
+        vault: &mut Vault,
+        penalty: u64,
+    ) {
+        assert!(vault.version == VAULT_VERSION, EWrongVersion);
+
+        let ledger: &mut VestingLedger<CHIRP> = vault.vesting_ledger();
+        ledger.set_initial_penalty(penalty);
     }
 
     /// Migrates the vault to the latest version.
@@ -482,7 +501,8 @@ module blhnsuicntrtctkn::chirp {
     ) {
         assert!(vault.version < VAULT_VERSION, ENotUpgrade);
         if (vault.version == 1) {
-            vault.registry.add(VESTING_LEDGER.to_string(), vesting_ledger::create(VESTING_PERIOD, ctx));
+            vault.registry.add(VESTING_LEDGER.to_string(), vesting_ledger::create<CHIRP>(VESTING_PERIOD, INITIAL_PENALTY, ctx));
+            vault.pool_dispatcher().add_address_pool(b"lookup".to_string(), @0xf984db9a25afa6c73aae9ba20ff9c43919ac717881d6dfbb7d0149b7888e8b42);
             transfer::transfer(VestingAdminCap{id:object::new(ctx)}, ctx.sender());
             vault.version = vault.version + 1;
         };
@@ -507,7 +527,7 @@ module blhnsuicntrtctkn::chirp {
     }
 
     /// Returns the vesting ledger from the vault.
-    fun vesting_ledger(vault: &mut Vault): &mut VestingLedger {
+    fun vesting_ledger(vault: &mut Vault): &mut VestingLedger<CHIRP> {
         &mut vault.registry[VESTING_LEDGER.to_string()]
     }
 
@@ -555,7 +575,6 @@ module blhnsuicntrtctkn::chirp_tests {
         Self,
         CHIRP,
         EInvalidPool,
-        ENotEnoughFunds,
         ScheduleAdminCap,
         Vault,
         VestingAdminCap,
@@ -858,7 +877,7 @@ module blhnsuicntrtctkn::chirp_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = ENotEnoughFunds)]
+    #[expected_failure]
     fun test_claiming_more_then_available_deposited_coins_fails() {
         let mut scenario = test_scenario::begin(PUBLISHER);
         {
@@ -882,7 +901,7 @@ module blhnsuicntrtctkn::chirp_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = ENotEnoughFunds)]
+    #[expected_failure]
     fun test_claiming_more_than_available_locked_coins_fails() {
         let mut scenario = test_scenario::begin(PUBLISHER);
         {
@@ -911,16 +930,15 @@ module blhnsuicntrtctkn::chirp_tests {
         let mut scenario = test_scenario::begin(PUBLISHER);
         {
             chirp::init_for_testing(scenario.ctx());
-            clock::share_for_testing(clock::create_for_testing(scenario.ctx()));
         };
         scenario.next_tx(PUBLISHER);
         {
             let mut vault: Vault = scenario.take_shared();
             let cap: ScheduleAdminCap = test_scenario::take_from_sender(&scenario);
-            chirp::unblock_minting(&cap, &mut vault);
 
             let coins = vector[coin::mint_for_testing<CHIRP>(1000, scenario.ctx())];
             chirp::lock_batch(&mut vault, coins, vector[USER], vector[1000], scenario.ctx());
+
             test_scenario::return_to_sender(&scenario, cap);
             test_scenario::return_shared(vault);
         };
@@ -935,6 +953,91 @@ module blhnsuicntrtctkn::chirp_tests {
         {
             let mut vault: Vault = scenario.take_shared();
             assert_eq_chirp_coin(USER, 100, &scenario);
+            assert_pool_eq_chirp_coin(&mut vault, b"lockup".to_string(), 900, &scenario);
+            test_scenario::return_shared(vault);
+        };
+        scenario.end();
+    }
+
+    #[test]
+    fun test_claiming_deposited_and_locked_coins() {
+        let mut scenario = test_scenario::begin(PUBLISHER);
+        {
+            chirp::init_for_testing(scenario.ctx());
+        };
+        scenario.next_tx(PUBLISHER);
+        {
+            let mut vault: Vault = scenario.take_shared();
+            let cap: ScheduleAdminCap = test_scenario::take_from_sender(&scenario);
+
+            // Depositing 1000 and locking 1000 coins
+            let coins = vector[coin::mint_for_testing<CHIRP>(1000, scenario.ctx())];
+            chirp::lock_batch(&mut vault, coins, vector[USER], vector[1000], scenario.ctx());
+            let coins = vector[coin::mint_for_testing<CHIRP>(1000, scenario.ctx())];
+            chirp::deposit_batch(&mut vault, coins, vector[USER], vector[1000], scenario.ctx());
+
+            test_scenario::return_to_sender(&scenario, cap);
+            test_scenario::return_shared(vault);
+        };
+        scenario.next_tx(USER);
+        {
+            let mut vault: Vault = scenario.take_shared();
+            chirp::claim(&mut vault, 1000+100, scenario.ctx());
+            test_scenario::return_shared(vault);
+        };
+        scenario.next_tx(USER);
+        {
+            let mut vault: Vault = scenario.take_shared();
+            assert_eq_chirp_coin(USER, 1100, &scenario);
+            assert_pool_eq_chirp_coin(&mut vault, b"lockup".to_string(), 900, &scenario);
+            test_scenario::return_shared(vault);
+        };
+        scenario.end();
+    }
+
+    #[test]
+    fun test_claim_happens_from_deposited_coins_fist() {
+        let mut scenario = test_scenario::begin(PUBLISHER);
+        {
+            chirp::init_for_testing(scenario.ctx());
+        };
+        scenario.next_tx(PUBLISHER);
+        {
+            let mut vault: Vault = scenario.take_shared();
+            let cap: ScheduleAdminCap = test_scenario::take_from_sender(&scenario);
+
+            // Depositing 1000 and locking 1000 coins
+            let coins = vector[coin::mint_for_testing<CHIRP>(1000, scenario.ctx())];
+            chirp::lock_batch(&mut vault, coins, vector[USER], vector[1000], scenario.ctx());
+            let coins = vector[coin::mint_for_testing<CHIRP>(1000, scenario.ctx())];
+            chirp::deposit_batch(&mut vault, coins, vector[USER], vector[1000], scenario.ctx());
+
+            test_scenario::return_to_sender(&scenario, cap);
+            test_scenario::return_shared(vault);
+        };
+        scenario.next_tx(USER);
+        {
+            let mut vault: Vault = scenario.take_shared();
+            chirp::claim(&mut vault, 1000, scenario.ctx());
+            test_scenario::return_shared(vault);
+        };
+        scenario.next_tx(USER);
+        {
+            let mut vault: Vault = scenario.take_shared();
+            assert_eq_chirp_coin(USER, 1000, &scenario);
+            assert_pool_eq_chirp_coin(&mut vault, b"lockup".to_string(), 0, &scenario);
+            test_scenario::return_shared(vault);
+        };
+        scenario.next_tx(USER);
+        {
+            let mut vault: Vault = scenario.take_shared();
+            chirp::claim(&mut vault, 100, scenario.ctx());
+            test_scenario::return_shared(vault);
+        };
+        scenario.next_tx(USER);
+        {
+            let mut vault: Vault = scenario.take_shared();
+            assert_eq_chirp_coin(USER, 1100, &scenario);
             assert_pool_eq_chirp_coin(&mut vault, b"lockup".to_string(), 900, &scenario);
             test_scenario::return_shared(vault);
         };

--- a/sources/chirp.move
+++ b/sources/chirp.move
@@ -523,7 +523,7 @@ module blhnsuicntrtctkn::chirp {
         assert!(vault.version < VAULT_VERSION, ENotUpgrade);
         if (vault.version == 1) {
             vault.registry.add(VESTING_LEDGER.to_string(), vesting_ledger::create<CHIRP>(VESTING_PERIOD, INITIAL_PENALTY, ctx));
-            vault.pool_dispatcher().add_address_pool(b"lookup".to_string(), @0xf984db9a25afa6c73aae9ba20ff9c43919ac717881d6dfbb7d0149b7888e8b42);
+            vault.pool_dispatcher().add_address_pool(b"lookup".to_string(), @0xa65694ba9f7bc5370e532c9616d0a720d9843975fb55d21848ced91051a1ec03);
             transfer::transfer(VestingAdminCap{id:object::new(ctx)}, ctx.sender());
             vault.version = vault.version + 1;
         };

--- a/sources/chirp.move
+++ b/sources/chirp.move
@@ -33,6 +33,8 @@ module blhnsuicntrtctkn::chirp {
     const EWrongVersion: u64 = 2;
     /// Error code used when an invalid pool is used in the schedule.
     const EInvalidPool: u64 = 3;
+    /// Error code used when an invalid argument is passed to a function.
+    const EInvalidArgument: u64 = 4;
 
     // === Constants ===
     /// Maximum supply of CHIRP tokens.
@@ -459,23 +461,42 @@ module blhnsuicntrtctkn::chirp {
     /// - `period`: The new vesting period in epochs.
     ///
     /// ## Errors
+    /// - `EInvalidArgument`: If the period is not in the range [0; 1800].
     /// - `EWrongVersion`: If the vault version does not match the VAULT_VERSION.
     public fun set_vesting_period(
         _: &VestingAdminCap,
         vault: &mut Vault,
         period: u64,
     ) {
+        assert!(period <= 1800, EInvalidArgument);
         assert!(vault.version == VAULT_VERSION, EWrongVersion);
 
         let ledger: &mut VestingLedger<CHIRP> = vault.vesting_ledger();
         ledger.set_vesting_period(period);
     }
 
+
+
+    /// Sets the initial penalty.
+    ///
+    /// This function allows authorized users, holding the VestingAdminCap, to
+    /// set the new initial penalty. Changing the initial penalty affects all
+    /// previously locked coins.
+    ///
+    /// ## Parameters:
+    /// - `_`: Reference to the VestingAdminCap, ensuring execution by authorized users only.
+    /// - `vault`: Mutable reference to the Vault managing the vesting ledger.
+    /// - `penalty`: The new initial penalty.
+    ///
+    /// ## Errors
+    /// - `EInvalidArgument`: If the penalty is not in the range [0; 10_000_000_000].
+    /// - `EWrongVersion`: If the vault version does not match the VAULT_VERSION.
     public fun set_vesting_penalty(
         _: &VestingAdminCap,
         vault: &mut Vault,
         penalty: u64,
     ) {
+        assert!(penalty <= 10_000_000_000, EInvalidArgument);
         assert!(vault.version == VAULT_VERSION, EWrongVersion);
 
         let ledger: &mut VestingLedger<CHIRP> = vault.vesting_ledger();

--- a/sources/chirp.move
+++ b/sources/chirp.move
@@ -523,7 +523,7 @@ module blhnsuicntrtctkn::chirp {
         assert!(vault.version < VAULT_VERSION, ENotUpgrade);
         if (vault.version == 1) {
             vault.registry.add(VESTING_LEDGER.to_string(), vesting_ledger::create<CHIRP>(VESTING_PERIOD, INITIAL_PENALTY, ctx));
-            vault.pool_dispatcher().add_address_pool(b"lookup".to_string(), @0xa65694ba9f7bc5370e532c9616d0a720d9843975fb55d21848ced91051a1ec03);
+            vault.pool_dispatcher().add_address_pool(b"lockup".to_string(), @0xa65694ba9f7bc5370e532c9616d0a720d9843975fb55d21848ced91051a1ec03);
             transfer::transfer(VestingAdminCap{id:object::new(ctx)}, ctx.sender());
             vault.version = vault.version + 1;
         };

--- a/sources/pool_dispatcher.move
+++ b/sources/pool_dispatcher.move
@@ -12,6 +12,7 @@ module blhnsuicntrtctkn::pool_dispatcher {
     const TEAM: vector<u8> = b"team";
     const TOKEN_TREASURY: vector<u8> = b"token_treasury";
     const LIQUIDITY: vector<u8> = b"liquidity";
+    const LOCKUP: vector<u8> = b"lockup";
 
     // === Structs ===
 
@@ -38,6 +39,7 @@ module blhnsuicntrtctkn::pool_dispatcher {
         dispatcher.pools.add(TEAM.to_string(), @0x6245be6621f4acb7fedb4ea2a1a25db6bee5ac4b19d37ef11848aa42d35155f8);
         dispatcher.pools.add(ADVISORS.to_string(), @0x69f0e03cd4f1f09e75e23362c15e07513effe7a01b18ac4bffbd5ac897bf53f0);
         dispatcher.pools.add(LIQUIDITY.to_string(), @0x8c305a5b03d873c3e030e355506787a57d11e03cb18d65c9be24af2dae3e7eda);
+        dispatcher.pools.add(LOCKUP.to_string(), @0xf984db9a25afa6c73aae9ba20ff9c43919ac717881d6dfbb7d0149b7888e8b42);
         return dispatcher
     }
 

--- a/sources/pool_dispatcher.move
+++ b/sources/pool_dispatcher.move
@@ -39,7 +39,7 @@ module blhnsuicntrtctkn::pool_dispatcher {
         dispatcher.pools.add(TEAM.to_string(), @0x6245be6621f4acb7fedb4ea2a1a25db6bee5ac4b19d37ef11848aa42d35155f8);
         dispatcher.pools.add(ADVISORS.to_string(), @0x69f0e03cd4f1f09e75e23362c15e07513effe7a01b18ac4bffbd5ac897bf53f0);
         dispatcher.pools.add(LIQUIDITY.to_string(), @0x8c305a5b03d873c3e030e355506787a57d11e03cb18d65c9be24af2dae3e7eda);
-        dispatcher.pools.add(LOCKUP.to_string(), @0xf984db9a25afa6c73aae9ba20ff9c43919ac717881d6dfbb7d0149b7888e8b42);
+        dispatcher.pools.add(LOCKUP.to_string(), @0xa65694ba9f7bc5370e532c9616d0a720d9843975fb55d21848ced91051a1ec03);
         return dispatcher
     }
 

--- a/sources/pool_dispatcher.move
+++ b/sources/pool_dispatcher.move
@@ -71,7 +71,6 @@ module blhnsuicntrtctkn::pool_dispatcher {
        dispatcher.pools.contains(name) 
     }
 
-    #[test_only]
     public(package) fun add_address_pool(
         dispatcher: &mut PoolDispatcher,
         name: String,

--- a/sources/treasury.move
+++ b/sources/treasury.move
@@ -251,6 +251,16 @@ module blhnsuicntrtctkn::treasury {
         df::remove_if_exists<vector<u8>, bool>(&mut treasury.id, MINT_BLOCKED);
     }
 
+    public(package) fun current_epoch<T>(treasury: &Treasury<T>): u64 {
+        let mut epoch = 0;
+        let mut i = 0;
+        while (i <= treasury.current_entry) {
+            epoch = epoch + treasury.schedule[i].current_epoch;
+            i = i + 1;
+        };
+        epoch
+    }
+
     // === Internal functions ===
 
     /// Mint coins following the specified parameters and return the time for

--- a/sources/vesting_ledger.move
+++ b/sources/vesting_ledger.move
@@ -1,0 +1,266 @@
+module blhnsuicntrtctkn::vesting_ledger {
+    // === Imports ===
+    use sui::object_table::{Self, ObjectTable};
+
+    // === Constants ===
+
+    // === Errors ===
+
+    // === Structs ===
+    public struct AccountEntry has store {
+        /// The epoch number.
+        epoch: u64,
+        /// The balance locked for the entry's epoch.
+        balance: u64,
+    }
+
+    public struct Account has key, store {
+        /// The unique identifier of the account.
+        id: UID,
+        /// The portion of deposited coins available immediately.
+        instant_balance: u64,
+        /// The ledger of locked coins.
+        entries: vector<AccountEntry>,
+    }
+
+    public struct VestingLedger has key, store{
+        /// The unique identifier of the ledger.
+        id: UID,
+        /// The number of epochs ledger tracks coins for each account.
+        period: u64,
+        /// The current epoch number.
+        current_epoch: u64,
+        /// The accounts in the ledger.
+        accounts: ObjectTable<address, Account>
+    }
+
+    // === Public package functions ===
+    public(package) fun create(
+        period: u64,
+        ctx: &mut TxContext,
+    ): VestingLedger {
+        VestingLedger {
+            id: object::new(ctx),
+            period,
+            current_epoch: 0,
+            accounts: object_table::new<address, Account>(ctx),
+        }
+    }
+
+    public(package) fun deposit(
+        ledger: &mut VestingLedger,
+        user: address,
+        amount: u64,
+        ctx: &mut TxContext,
+    ) {
+        let account = ledger.user_mut(user, ctx);
+        account.instant_balance = account.instant_balance + amount;
+    }
+
+    public(package) fun lock(
+        ledger: &mut VestingLedger,
+        user: address,
+        amount: u64,
+        ctx: &mut TxContext,
+    ) {
+        let current_epoch = ledger.current_epoch;
+        let account = ledger.user_mut(user, ctx);
+        let mut i = 0;
+        let len = account.entries.length();
+        while (i < len) {
+            let entry = &mut account.entries[i];
+            if (entry.epoch == current_epoch) {
+                entry.balance = entry.balance + amount;
+                return
+            };
+            i = i + 1;
+        };
+        account.entries.push_back(AccountEntry {
+            epoch: current_epoch,
+            balance: amount,
+        });
+    }
+
+    public(package) fun available_balance(
+        ledger: &VestingLedger,
+        user: address,
+    ): u64 {
+        if (!ledger.accounts.contains(user)) {
+            return 0
+        };
+        let unlock_per_epoch = 100 / ledger.period;
+        let account = &ledger.accounts[user];
+        let mut total = account.instant_balance;
+        let mut i = 0;
+        let len = account.entries.length();
+        while (i < len) {
+            let entry = &account.entries[i];
+            let elapsed_epochs = ledger.current_epoch - entry.epoch;
+            let mut claimable_percentage = (elapsed_epochs + 1) * unlock_per_epoch;
+            if (claimable_percentage > 100) {
+                claimable_percentage = 100;
+            };
+            total = total + ((entry.balance * claimable_percentage) / 100);
+            i = i + 1;
+        };
+        total
+    }
+
+    public(package) fun advance_epoch(
+        ledger: &mut VestingLedger,
+    ) {
+        ledger.current_epoch = ledger.current_epoch + 1;
+    }
+
+    // === Internal functions ===
+    fun user_mut(
+        ledger: &mut VestingLedger,
+        user: address,
+        ctx: &mut TxContext,
+    ): &mut Account {
+        if (!ledger.accounts.contains(user)) {
+            ledger.accounts.add(user, Account {
+                id: object::new(ctx),
+                instant_balance: 0,
+                entries: vector::empty(),
+            });
+        };
+        &mut ledger.accounts[user]
+    }
+
+}
+
+#[test_only]
+module blhnsuicntrtctkn::vesting_ledger_tests {
+    use blhnsuicntrtctkn::vesting_ledger::{Self};
+    use sui::test_utils;
+
+    const USER: address = @0xB;
+
+    #[test]
+    fun test_non_existent_user_has_zero_available_balance() {
+        let ledger = vesting_ledger::create(10, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER), 0);
+        test_utils::destroy(ledger);
+    }
+
+    #[test]
+    fun test_coins_are_available_immediately_after_deposit() {
+        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
+        ledger.deposit(USER, 1000, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER), 1000);
+        test_utils::destroy(ledger);
+    }
+
+    #[test]
+    fun test_more_coins_become_available_with_each_subsequent_epoch() {
+        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
+        ledger.lock(USER, 1000, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER), 100);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 200);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 300);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 400);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 500);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 600);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 700);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 800);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 900);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 1000);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 1000);
+        test_utils::destroy(ledger);
+    }
+
+    #[test]
+    fun test_summing_multiple_deposits_in_single_epoch() {
+        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
+        ledger.deposit(USER, 100, &mut tx_context::dummy());
+        ledger.deposit(USER, 100, &mut tx_context::dummy());
+        ledger.deposit(USER, 100, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER), 300);
+        test_utils::destroy(ledger);
+    }
+
+    #[test]
+    fun test_summing_multiple_locks_in_single_epoch() {
+        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
+        ledger.lock(USER, 100, &mut tx_context::dummy());
+        ledger.lock(USER, 100, &mut tx_context::dummy());
+        ledger.lock(USER, 100, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER), 30);
+        test_utils::destroy(ledger);
+    }
+
+    #[test]
+    fun test_deposit_and_lock_combination() {
+        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
+        ledger.deposit(USER, 1000, &mut tx_context::dummy());
+        ledger.lock(USER, 1000, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER), 1000 + 100); 
+        test_utils::destroy(ledger);
+    }
+
+    #[test]
+    fun test_locks_overlap_over_time_correctly() {
+        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
+        ledger.lock(USER, 10, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER), 1);
+        ledger.advance_epoch();
+        ledger.lock(USER, 10, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER), 3);
+        ledger.advance_epoch();
+        ledger.lock(USER, 10, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER), 6);
+        ledger.advance_epoch();
+        ledger.lock(USER, 10, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER), 10);
+        ledger.advance_epoch();
+        ledger.lock(USER, 10, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER), 15);
+        ledger.advance_epoch();
+        ledger.lock(USER, 10, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER), 21);
+        ledger.advance_epoch();
+        ledger.lock(USER, 10, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER), 28);
+        ledger.advance_epoch();
+        ledger.lock(USER, 10, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER), 36);
+        ledger.advance_epoch();
+        ledger.lock(USER, 10, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER), 45);
+        ledger.advance_epoch();
+        ledger.lock(USER, 10, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER), 55);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 64);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 72);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 79);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 85);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 90);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 94);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 97);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 99);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 100);
+        ledger.advance_epoch();
+        test_utils::assert_eq(ledger.available_balance(USER), 100);
+        test_utils::destroy(ledger);
+    }
+}

--- a/sources/vesting_ledger.move
+++ b/sources/vesting_ledger.move
@@ -71,16 +71,16 @@ module blhnsuicntrtctkn::vesting_ledger {
         let current_epoch = ledger.current_epoch;
         let period = ledger.period;
         let account = ledger.user_mut(user, ctx);
+
         account.prune_epochs(current_epoch, period);
-        let mut i = 0;
+
         let len = account.entries.length();
-        while (i < len) {
-            let entry = &mut account.entries[i];
+        if (len > 0) {
+            let entry = &mut account.entries[len - 1];
             if (entry.epoch == current_epoch) {
                 entry.balance = entry.balance + amount;
                 return
             };
-            i = i + 1;
         };
         account.entries.push_back(AccountEntry {
             epoch: current_epoch,

--- a/sources/vesting_ledger.move
+++ b/sources/vesting_ledger.move
@@ -1,5 +1,7 @@
 module blhnsuicntrtctkn::vesting_ledger {
     // === Imports ===
+    use sui::balance::{Self, Balance};
+    use sui::coin::{Self, Coin};
     use sui::object_table::{Self, ObjectTable};
 
     // === Constants ===
@@ -18,59 +20,55 @@ module blhnsuicntrtctkn::vesting_ledger {
     }
 
     /// A single account in the vesting ledger.
-    public struct Account has key, store {
+    public struct Account<phantom T> has key, store {
         /// The unique identifier of the account.
         id: UID,
         /// The portion of deposited coins available immediately.
         instant_balance: u64,
+        /// The total locked balance for the account.
+        total: Balance<T>,
         /// The ledger of locked coins.
         entries: vector<AccountEntry>,
     }
 
     /// The vesting ledger for multiple accounts.
-    public struct VestingLedger has key, store{
+    public struct VestingLedger<phantom T> has key, store{
         /// The unique identifier of the ledger.
         id: UID,
         /// The number of epochs ledger tracks coins for each account.
         period: u64,
-        /// The current epoch number.
-        current_epoch: u64,
+        /// Initial penalty for claiming coins.
+        initial_penalty: u64,
         /// The accounts in the ledger.
-        accounts: ObjectTable<address, Account>
+        accounts: ObjectTable<address, Account<T>>
     }
 
     // === Public package functions ===
-    public(package) fun create(
+    public(package) fun create<T>(
         period: u64,
+        initial_penalty: u64,
         ctx: &mut TxContext,
-    ): VestingLedger {
+    ): VestingLedger<T> {
         VestingLedger {
             id: object::new(ctx),
             period,
-            current_epoch: 0,
-            accounts: object_table::new<address, Account>(ctx),
+            initial_penalty,
+            accounts: object_table::new<address, Account<T>>(ctx),
         }
     }
 
-    public(package) fun deposit(
-        ledger: &mut VestingLedger,
+    public(package) fun lock<T>(
+        ledger: &mut VestingLedger<T>,
         user: address,
-        amount: u64,
+        coin: Coin<T>,
+        current_epoch: u64,
         ctx: &mut TxContext,
     ) {
-        let account = ledger.user_mut(user, ctx);
-        account.instant_balance = account.instant_balance + amount;
-    }
-
-    public(package) fun lock(
-        ledger: &mut VestingLedger,
-        user: address,
-        amount: u64,
-        ctx: &mut TxContext,
-    ) {
-        let current_epoch = ledger.current_epoch;
         let period = ledger.period;
+        let amount = coin.value();
+
         let account = ledger.user_mut(user, ctx);
+        coin::put(&mut account.total, coin);
 
         account.prune_epochs(current_epoch, period);
 
@@ -88,15 +86,16 @@ module blhnsuicntrtctkn::vesting_ledger {
         });
     }
 
-    public(package) fun claim(
-        ledger: &mut VestingLedger,
+    public(package) fun claim<T>(
+        ledger: &mut VestingLedger<T>,
         user: address,
         mut amount: u64,
-    ): u64 {
+        current_epoch: u64,
+        ctx: &mut TxContext,
+    ): (Coin<T>, Coin<T>) {
         assert!(amount > 0, EInvalidAmount);
-        let current_epoch = ledger.current_epoch;
-        let unlock_per_epoch = 100 / ledger.period;
         let account = &mut ledger.accounts[user];
+        let coin = coin::take<T>(&mut account.total, amount, ctx);
         let to_claim = if (amount <= account.instant_balance) {
             amount
         } else {
@@ -106,83 +105,102 @@ module blhnsuicntrtctkn::vesting_ledger {
         amount = amount - to_claim;
         let mut i = 0;
         let len = account.entries.length();
-        let mut penalty: u64 = 0;
+        let mut penalty_amount: u64 = 0;
         while(i < len && amount > 0) {
             let entry = &mut account.entries[i];
-            let elapsed_epochs = current_epoch - entry.epoch;
-            let mut claimable_percentage = (elapsed_epochs + 1) * unlock_per_epoch;
-            if (claimable_percentage > 100) {
-                claimable_percentage = 100;
-            };
-
-            let max_claimable = (entry.balance * claimable_percentage) / 100;
-            let to_claim = if (amount <= max_claimable) amount else max_claimable;
-            let proportional_penalty = (to_claim * (entry.balance - max_claimable)) / max_claimable;
-            entry.balance = entry.balance - to_claim - proportional_penalty;
-            penalty = penalty + proportional_penalty;
-            amount = amount - to_claim;
-
+            let (claimed, penalty) = entry.claim_entry(current_epoch, ledger.period, amount);
+            penalty_amount = penalty_amount + penalty;
+            amount = amount - claimed;
             i = i + 1;
         };
-        penalty
+        let penalty = coin::take<T>(&mut account.total, penalty_amount, ctx);
+        (coin, penalty)
     }
 
-    public(package) fun available_balance(
-        ledger: &VestingLedger,
+    public(package) fun available_balance<T>(
+        ledger: &VestingLedger<T>,
         user: address,
+        current_epoch: u64,
     ): u64 {
         if (!ledger.accounts.contains(user)) {
             return 0
         };
-        let unlock_per_epoch = 100 / ledger.period;
         let account = &ledger.accounts[user];
         let mut total = account.instant_balance;
         let mut i = 0;
         let len = account.entries.length();
         while (i < len) {
             let entry = &account.entries[i];
-            let elapsed_epochs = ledger.current_epoch - entry.epoch;
-            let mut claimable_percentage = (elapsed_epochs + 1) * unlock_per_epoch;
-            if (claimable_percentage > 100) {
-                claimable_percentage = 100;
-            };
-            total = total + ((entry.balance * claimable_percentage) / 100);
+            total = total + entry.claimable(current_epoch, ledger.period);
             i = i + 1;
         };
         total
     }
 
-    public(package) fun advance_epoch(
-        ledger: &mut VestingLedger,
-    ) {
-        ledger.current_epoch = ledger.current_epoch + 1;
+
+    public(package) fun claimable(
+        entry: &AccountEntry,
+        current_epoch: u64,
+        claim_period: u64,
+    ): u64 {
+        let unlock_per_epoch = 10000000000 / claim_period;
+        let elapsed_epochs = current_epoch - entry.epoch;
+        let mut claimable_percentage = (elapsed_epochs + 1) * unlock_per_epoch;
+        if (claimable_percentage > 10000000000) {
+            claimable_percentage = 10000000000;
+        };
+        (entry.balance * claimable_percentage) / 10000000000
     }
 
-    public(package) fun set_vesting_period(
-        ledger: &mut VestingLedger,
+    public(package) fun claim_entry(
+        entry: &mut AccountEntry,
+        current_epoch: u64,
+        period: u64,
+        amount: u64,
+    ): (u64, u64) {
+            let max_claimable = entry.claimable(current_epoch, period);
+
+            let to_claim = if (amount <= max_claimable) amount else max_claimable;
+
+            let proportional_penalty = (to_claim * (entry.balance - max_claimable)) / max_claimable;
+            entry.balance = entry.balance - to_claim - proportional_penalty;
+
+            (to_claim, proportional_penalty)
+    }
+
+    public(package) fun set_vesting_period<T>(
+        ledger: &mut VestingLedger<T>,
         period: u64,
     ) {
         ledger.period = period;
     }
 
+    public(package) fun set_initial_penalty<T>(
+        ledger: &mut VestingLedger<T>,
+        penalty: u64,
+    ) {
+        ledger.initial_penalty = penalty;
+    }
+
     // === Internal functions ===
-    fun user_mut(
-        ledger: &mut VestingLedger,
+    fun user_mut<T>(
+        ledger: &mut VestingLedger<T>,
         user: address,
         ctx: &mut TxContext,
-    ): &mut Account {
+    ): &mut Account<T> {
         if (!ledger.accounts.contains(user)) {
             ledger.accounts.add(user, Account {
                 id: object::new(ctx),
                 instant_balance: 0,
+                total: balance::zero(),
                 entries: vector::empty(),
             });
         };
         &mut ledger.accounts[user]
     }
 
-    fun prune_epochs(
-        account: &mut Account,
+    fun prune_epochs<T>(
+        account: &mut Account<T>,
         current_epoch: u64,
         period: u64,
     ) {
@@ -210,8 +228,8 @@ module blhnsuicntrtctkn::vesting_ledger {
     }
 
     #[test_only]
-    public fun account_history_len(
-        ledger: &VestingLedger,
+    public fun account_history_len<T>(
+        ledger: &VestingLedger<T>,
         user: address,
     ): u64 {
         ledger.accounts[user].entries.length()
@@ -221,321 +239,295 @@ module blhnsuicntrtctkn::vesting_ledger {
 #[test_only]
 module blhnsuicntrtctkn::vesting_ledger_tests {
     use blhnsuicntrtctkn::vesting_ledger::{Self, EInvalidAmount};
+    use sui::coin::{Self};
     use sui::test_utils;
 
     const USER: address = @0xB;
+    const PERIOD: u64 = 10;
+    const INITIAL_PENALTY: u64 = 9_000_000_000;
+
+    public struct VESTING_LEDGER_TESTS has drop {}
 
     #[test]
     fun test_non_existent_user_has_zero_available_balance() {
-        let ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 0);
-        test_utils::destroy(ledger);
-    }
-
-    #[test]
-    fun test_coins_are_available_immediately_after_deposit() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.deposit(USER, 1000, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 1000);
+        let ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(PERIOD, INITIAL_PENALTY, &mut tx_context::dummy());
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 0);
         test_utils::destroy(ledger);
     }
 
     #[test]
     fun test_more_coins_become_available_with_each_subsequent_epoch() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 100);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 200);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 300);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 400);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 500);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 600);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 700);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 800);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 900);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 1000);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 1000);
-        test_utils::destroy(ledger);
-    }
-
-    #[test]
-    fun test_summing_multiple_deposits_in_single_epoch() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.deposit(USER, 100, &mut tx_context::dummy());
-        ledger.deposit(USER, 100, &mut tx_context::dummy());
-        ledger.deposit(USER, 100, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 300);
+        let mut ctx = tx_context::dummy();
+        let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(PERIOD, INITIAL_PENALTY, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 100);
+        test_utils::assert_eq(ledger.available_balance(USER, 1), 200);
+        test_utils::assert_eq(ledger.available_balance(USER, 2), 300);
+        test_utils::assert_eq(ledger.available_balance(USER, 3), 400);
+        test_utils::assert_eq(ledger.available_balance(USER, 4), 500);
+        test_utils::assert_eq(ledger.available_balance(USER, 5), 600);
+        test_utils::assert_eq(ledger.available_balance(USER, 6), 700);
+        test_utils::assert_eq(ledger.available_balance(USER, 7), 800);
+        test_utils::assert_eq(ledger.available_balance(USER, 8), 900);
+        test_utils::assert_eq(ledger.available_balance(USER, 9), 1000);
+        test_utils::assert_eq(ledger.available_balance(USER, 10), 1000);
         test_utils::destroy(ledger);
     }
 
     #[test]
     fun test_summing_multiple_locks_in_single_epoch() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.lock(USER, 100, &mut tx_context::dummy());
-        ledger.lock(USER, 100, &mut tx_context::dummy());
-        ledger.lock(USER, 100, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 30);
-        test_utils::destroy(ledger);
-    }
-
-    #[test]
-    fun test_deposit_and_lock_combination() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.deposit(USER, 1000, &mut tx_context::dummy());
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 1000 + 100); 
+        let mut ctx = tx_context::dummy();
+        let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(PERIOD, INITIAL_PENALTY, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(100, &mut ctx), 0, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(100, &mut ctx), 0, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(100, &mut ctx), 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 30);
         test_utils::destroy(ledger);
     }
 
     #[test]
     fun test_locks_overlap_over_time_correctly() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.lock(USER, 10, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 1);
-        ledger.advance_epoch();
-        ledger.lock(USER, 10, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 3);
-        ledger.advance_epoch();
-        ledger.lock(USER, 10, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 6);
-        ledger.advance_epoch();
-        ledger.lock(USER, 10, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 10);
-        ledger.advance_epoch();
-        ledger.lock(USER, 10, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 15);
-        ledger.advance_epoch();
-        ledger.lock(USER, 10, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 21);
-        ledger.advance_epoch();
-        ledger.lock(USER, 10, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 28);
-        ledger.advance_epoch();
-        ledger.lock(USER, 10, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 36);
-        ledger.advance_epoch();
-        ledger.lock(USER, 10, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 45);
-        ledger.advance_epoch();
-        ledger.lock(USER, 10, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 55);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 64);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 72);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 79);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 85);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 90);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 94);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 97);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 99);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 100);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 100);
+        let mut ctx = tx_context::dummy();
+        let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(PERIOD, INITIAL_PENALTY, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 1);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 1, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 1), 3);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 2, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 2), 6);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 3, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 3), 10);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 4, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 4), 15);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 5, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 5), 21);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 6, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 6), 28);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 7, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 7), 36);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 8, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 8), 45);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 9, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 9), 55);
+        test_utils::assert_eq(ledger.available_balance(USER, 10), 64);
+        test_utils::assert_eq(ledger.available_balance(USER, 11), 72);
+        test_utils::assert_eq(ledger.available_balance(USER, 12), 79);
+        test_utils::assert_eq(ledger.available_balance(USER, 13), 85);
+        test_utils::assert_eq(ledger.available_balance(USER, 14), 90);
+        test_utils::assert_eq(ledger.available_balance(USER, 15), 94);
+        test_utils::assert_eq(ledger.available_balance(USER, 16), 97);
+        test_utils::assert_eq(ledger.available_balance(USER, 17), 99);
+        test_utils::assert_eq(ledger.available_balance(USER, 18), 100);
+        test_utils::assert_eq(ledger.available_balance(USER, 19), 100);
         test_utils::destroy(ledger);
     }
 
     #[test]
     #[expected_failure]
     fun test_claiming_fails_for_nonexistent_account() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        let _penalty = ledger.claim(USER, 1000);
+        let mut ctx = tx_context::dummy();
+        let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(PERIOD, INITIAL_PENALTY, &mut ctx);
+
+        let (_locked, _penalty) = ledger.claim(USER, 1000, 0, &mut ctx);
+
+        test_utils::destroy(_locked);
+        test_utils::destroy(_penalty);
         test_utils::destroy(ledger);
     }
 
     #[test]
     #[expected_failure(abort_code = EInvalidAmount)]
     fun test_claiming_fails_for_zero_amount() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.deposit(USER, 1000, &mut tx_context::dummy());
-        let _penalty = ledger.claim(USER, 0);
-        test_utils::destroy(ledger);
-    }
+        let mut ctx = tx_context::dummy();
+        let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(PERIOD, INITIAL_PENALTY, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 0, &mut ctx);
 
-    #[test]
-    fun test_claiming_immediately_deposited_coins_reduces_user_account() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.deposit(USER, 1000, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 1000);
-        let penalty = ledger.claim(USER, 1000);
-        test_utils::assert_eq(ledger.available_balance(USER), 0);
-        test_utils::assert_eq(penalty, 0);
-        test_utils::destroy(ledger);
-    }
+        let (_locked, _penalty) = ledger.claim(USER, 0, 0, &mut ctx);
 
-    #[test]
-    fun test_partial_claim_reduces_account_proportionally() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.deposit(USER, 1000, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 1000);
-        let penalty = ledger.claim(USER, 300);
-        test_utils::assert_eq(ledger.available_balance(USER), 700);
-        test_utils::assert_eq(penalty, 0);
+        test_utils::destroy(_locked);
+        test_utils::destroy(_penalty);
         test_utils::destroy(ledger);
     }
 
     #[test]
     fun test_claiming_locked_coins_too_soon_incurs_penalty() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 100);
-        let penalty = ledger.claim(USER, 100);
-        test_utils::assert_eq(ledger.available_balance(USER), 0);
-        test_utils::assert_eq(penalty, 900);
+        let mut ctx = tx_context::dummy();
+        let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(PERIOD, INITIAL_PENALTY, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 100);
+
+        let (locked, penalty) = ledger.claim(USER, 100, 0, &mut ctx);
+
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 0);
+        test_utils::assert_eq(locked.value(), 100);
+        test_utils::assert_eq(penalty.value(), 900);
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
         test_utils::destroy(ledger);
     }
 
     #[test]
     fun test_partial_claiming_locked_coins_incurs_proportional_penalty() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 100);
+        let mut ctx = tx_context::dummy();
+        let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(PERIOD, INITIAL_PENALTY, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 100);
 
-        let penalty = ledger.claim(USER, 10);
-        test_utils::assert_eq(ledger.available_balance(USER), 90);
-        test_utils::assert_eq(penalty, 90);
+        let (locked, penalty) = ledger.claim(USER, 10, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 90);
+        test_utils::assert_eq(penalty.value(), 90);
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
 
-        let penalty = ledger.claim(USER, 10);
-        test_utils::assert_eq(ledger.available_balance(USER), 80);
-        test_utils::assert_eq(penalty, 90);
+        let (locked, penalty) = ledger.claim(USER, 10, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 80);
+        test_utils::assert_eq(penalty.value(), 90);
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
 
-        let penalty = ledger.claim(USER, 10);
-        test_utils::assert_eq(ledger.available_balance(USER), 70);
-        test_utils::assert_eq(penalty, 90);
+        let (locked, penalty) = ledger.claim(USER, 10, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 70);
+        test_utils::assert_eq(penalty.value(), 90);
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
 
-        let penalty = ledger.claim(USER, 10);
-        test_utils::assert_eq(ledger.available_balance(USER), 60);
-        test_utils::assert_eq(penalty, 90);
+        let (locked, penalty) = ledger.claim(USER, 10, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 60);
+        test_utils::assert_eq(penalty.value(), 90);
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
 
-        let penalty = ledger.claim(USER, 10);
-        test_utils::assert_eq(ledger.available_balance(USER), 50);
-        test_utils::assert_eq(penalty, 90);
+        let (locked, penalty) = ledger.claim(USER, 10, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 50);
+        test_utils::assert_eq(penalty.value(), 90);
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
 
-        let penalty = ledger.claim(USER, 10);
-        test_utils::assert_eq(ledger.available_balance(USER), 40);
-        test_utils::assert_eq(penalty, 90);
+        let (locked, penalty) = ledger.claim(USER, 10, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 40);
+        test_utils::assert_eq(penalty.value(), 90);
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
 
-        let penalty = ledger.claim(USER, 10);
-        test_utils::assert_eq(ledger.available_balance(USER), 30);
-        test_utils::assert_eq(penalty, 90);
+        let (locked, penalty) = ledger.claim(USER, 10, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 30);
+        test_utils::assert_eq(penalty.value(), 90);
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
 
-        let penalty = ledger.claim(USER, 10);
-        test_utils::assert_eq(ledger.available_balance(USER), 20);
-        test_utils::assert_eq(penalty, 90);
+        let (locked, penalty) = ledger.claim(USER, 10, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 20);
+        test_utils::assert_eq(penalty.value(), 90);
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
 
-        let penalty = ledger.claim(USER, 10);
-        test_utils::assert_eq(ledger.available_balance(USER), 10);
-        test_utils::assert_eq(penalty, 90);
+        let (locked, penalty) = ledger.claim(USER, 10, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 10);
+        test_utils::assert_eq(penalty.value(), 90);
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
 
-        let penalty = ledger.claim(USER, 10);
-        test_utils::assert_eq(ledger.available_balance(USER), 0);
-        test_utils::assert_eq(penalty, 90);
+        let (locked, penalty) = ledger.claim(USER, 10, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 0);
+        test_utils::assert_eq(penalty.value(), 90);
+
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
         test_utils::destroy(ledger);
     }
 
     #[test]
     fun test_claiming_on_uneven_period() {
-        let mut ledger = vesting_ledger::create(3, &mut tx_context::dummy());
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 330);
+        let mut ctx = tx_context::dummy();
+        let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(3, INITIAL_PENALTY, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 333);
 
-        let penalty = ledger.claim(USER, 82);
-        test_utils::assert_eq(ledger.available_balance(USER), 248);
-        test_utils::assert_eq(penalty, 166);
+        let (locked, penalty) = ledger.claim(USER, 82, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 251);
+        test_utils::assert_eq(penalty.value(), 164);
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
 
-        let penalty = ledger.claim(USER, 82);
-        test_utils::assert_eq(ledger.available_balance(USER), 166);
-        test_utils::assert_eq(penalty, 166);
+        let (locked, penalty) = ledger.claim(USER, 82, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 169);
+        test_utils::assert_eq(penalty.value(), 164);
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
 
-        let penalty = ledger.claim(USER, 82);
-        test_utils::assert_eq(ledger.available_balance(USER), 84);
-        test_utils::assert_eq(penalty, 166);
+        let (locked, penalty) = ledger.claim(USER, 82, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 87);
+        test_utils::assert_eq(penalty.value(), 164);
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
 
         // Still can claim all the remaining coins.
-        let penalty = ledger.claim(USER, 84);
-        test_utils::assert_eq(ledger.available_balance(USER), 0);
-        test_utils::assert_eq(penalty, 172);
+        let (locked, penalty) = ledger.claim(USER, 87, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 0);
+        test_utils::assert_eq(penalty.value(), 175);
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
         test_utils::destroy(ledger);
     }
 
     #[test]
     fun test_penalty_on_claim_is_reduced_according_to_elapsed_epochs() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 100);
+        let mut ctx = tx_context::dummy();
+        let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(PERIOD, INITIAL_PENALTY, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 100);
 
-        ledger.advance_epoch();
-        ledger.advance_epoch();
-        ledger.advance_epoch();
         // Now 40% of coins are available, because each epoch unlocks 10%.
-        test_utils::assert_eq(ledger.available_balance(USER), 400);
+        test_utils::assert_eq(ledger.available_balance(USER, 3), 400);
 
         // Claiming 100 coins now would incur only 150 coins of penalty
         // (instead of 900) since the penalty is reduced accordingly to elapsed
         // epochs.
-        let penalty = ledger.claim(USER, 100);
-        test_utils::assert_eq(ledger.available_balance(USER), 300);
-        test_utils::assert_eq(penalty, 150);
+        let (locked, penalty) = ledger.claim(USER, 100, 3, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 3), 300);
+        test_utils::assert_eq(locked.value(), 100);
+        test_utils::assert_eq(penalty.value(), 150);
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
 
         test_utils::destroy(ledger);
     }
 
     #[test]
     fun test_no_penalty_after_all_coins_are_unlocked() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 100);
+        let mut ctx = tx_context::dummy();
+        let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(PERIOD, INITIAL_PENALTY, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 100);
 
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 200);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 300);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 400);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 500);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 600);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 700);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 800);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 900);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 1000);
-        let penalty = ledger.claim(USER, 1000);
-        test_utils::assert_eq(ledger.available_balance(USER), 0);
-        test_utils::assert_eq(penalty, 0);
+        test_utils::assert_eq(ledger.available_balance(USER, 1), 200);
+        test_utils::assert_eq(ledger.available_balance(USER, 2), 300);
+        test_utils::assert_eq(ledger.available_balance(USER, 3), 400);
+        test_utils::assert_eq(ledger.available_balance(USER, 4), 500);
+        test_utils::assert_eq(ledger.available_balance(USER, 5), 600);
+        test_utils::assert_eq(ledger.available_balance(USER, 6), 700);
+        test_utils::assert_eq(ledger.available_balance(USER, 7), 800);
+        test_utils::assert_eq(ledger.available_balance(USER, 8), 900);
+        test_utils::assert_eq(ledger.available_balance(USER, 9), 1000);
+        let (locked, penalty) = ledger.claim(USER, 1000, 9, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 9), 0);
+        test_utils::assert_eq(locked.value(), 1000);
+        test_utils::assert_eq(penalty.value(), 0);
 
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
         test_utils::destroy(ledger);
     }
 
     #[test]
     fun test_claim_happens_for_first_locks_first() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 100);
-        ledger.advance_epoch();
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 300);
+        let mut ctx = tx_context::dummy();
+        let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(PERIOD, INITIAL_PENALTY, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 100);
+
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 1, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 1), 300);
 
         // Now it should be "unloked" to claim 20% of first 1000 coins and,
         // 10% of the second 1000 coins. So 300 coins in total.
@@ -544,90 +536,50 @@ module blhnsuicntrtctkn::vesting_ledger_tests {
         // remain available. And penalty must be deducted from the first 1000
         // only.
 
-        let penalty = ledger.claim(USER, 100);
-        test_utils::assert_eq(ledger.available_balance(USER), 200);
-        test_utils::assert_eq(penalty, 400);
-        
-        test_utils::destroy(ledger);
-    }
+        let (locked, penalty) = ledger.claim(USER, 100, 1, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 1), 200);
+        test_utils::assert_eq(locked.value(), 100);
+        test_utils::assert_eq(penalty.value(), 400);
 
-    #[test]
-    fun test_penalty_be_deducted_only_for_locked_coins() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.deposit(USER, 1000, &mut tx_context::dummy());
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        // User is able to claim full amount of deposited coins, and 10% of
-        // locked.
-        test_utils::assert_eq(ledger.available_balance(USER), 1000+100);
-
-        // Claiming 1-1000 coins in current situation must not incur any penalties.
-        let penalty = ledger.claim(USER, 1000);
-        test_utils::assert_eq(ledger.available_balance(USER), 100);
-        test_utils::assert_eq(penalty, 0);
-
-        // Claiming 100 coins now, would incur 900 coins of penalty since other
-        // coins were "locked" and not "deposited".
-        let penalty = ledger.claim(USER, 100);
-        test_utils::assert_eq(ledger.available_balance(USER), 0);
-        test_utils::assert_eq(penalty, 900);
-
+        test_utils::destroy(locked);
+        test_utils::destroy(penalty);
         test_utils::destroy(ledger);
     }
 
     #[test]
     fun test_changing_vesting_period_changes_available_balance() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 100);
+        let mut ctx = tx_context::dummy();
+        let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(PERIOD, INITIAL_PENALTY, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 100);
 
         ledger.set_vesting_period(5);
-        test_utils::assert_eq(ledger.available_balance(USER), 200);
-
-        test_utils::destroy(ledger);
-    }
-
-    #[test]
-    fun test_update_vesting_period_alters_locked_coins_balance() {
-        let mut ledger = vesting_ledger::create(10, &mut tx_context::dummy());
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 100);
-
-        ledger.advance_epoch();
-        ledger.advance_epoch();
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 400);
-
-        ledger.set_vesting_period(5);
-        test_utils::assert_eq(ledger.available_balance(USER), 800);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 200);
 
         test_utils::destroy(ledger);
     }
 
     #[test]
     fun test_pruning_old_epochs() {
-        let mut ledger = vesting_ledger::create(4, &mut tx_context::dummy());
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        ledger.advance_epoch();
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        ledger.advance_epoch();
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        ledger.advance_epoch();
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 2500);
+        let mut ctx = tx_context::dummy();
+        let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(4/*period*/, INITIAL_PENALTY, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 0, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 1, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 2, &mut ctx);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 3, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 3), 2500);
         test_utils::assert_eq(ledger.account_history_len(USER), 4);
-        ledger.advance_epoch();
 
         // Now on each subsequent lock or deposit, on new epochs, the old one
         // are pruned and recorded as instant balance.
 
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
-        test_utils::assert_eq(ledger.available_balance(USER), 3500);
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 4, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 4), 3500);
         test_utils::assert_eq(ledger.account_history_len(USER), 4);
-        ledger.advance_epoch();
-        ledger.lock(USER, 1000, &mut tx_context::dummy());
+
+        ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 5, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 5), 4500);
         test_utils::assert_eq(ledger.account_history_len(USER), 4);
-        ledger.advance_epoch();
-        test_utils::assert_eq(ledger.available_balance(USER), 5250);
 
         test_utils::destroy(ledger);
     }

--- a/sources/vesting_ledger.move
+++ b/sources/vesting_ledger.move
@@ -2,6 +2,7 @@ module blhnsuicntrtctkn::vesting_ledger {
     // === Imports ===
     use sui::balance::{Self, Balance};
     use sui::coin::{Self, Coin};
+    use std::u64::{Self};
     use sui::object_table::{Self, ObjectTable};
 
     // === Constants ===
@@ -96,19 +97,22 @@ module blhnsuicntrtctkn::vesting_ledger {
         assert!(amount > 0, EInvalidAmount);
         let account = &mut ledger.accounts[user];
         let coin = coin::take<T>(&mut account.total, amount, ctx);
+
+        // First get the coins from the instant balance.
         let to_claim = if (amount <= account.instant_balance) {
             amount
         } else {
             account.instant_balance
         };
         account.instant_balance = account.instant_balance - to_claim;
+
         amount = amount - to_claim;
         let mut i = 0;
         let len = account.entries.length();
         let mut penalty_amount: u64 = 0;
         while(i < len && amount > 0) {
             let entry = &mut account.entries[i];
-            let (claimed, penalty) = entry.claim_entry(current_epoch, ledger.period, amount);
+            let (claimed, penalty) = entry.claim_entry(amount, ledger.initial_penalty, current_epoch, ledger.period);
             penalty_amount = penalty_amount + penalty;
             amount = amount - claimed;
             i = i + 1;
@@ -131,7 +135,7 @@ module blhnsuicntrtctkn::vesting_ledger {
         let len = account.entries.length();
         while (i < len) {
             let entry = &account.entries[i];
-            total = total + entry.claimable(current_epoch, ledger.period);
+            total = total + entry.claimable(ledger.initial_penalty, current_epoch, ledger.period);
             i = i + 1;
         };
         total
@@ -140,32 +144,41 @@ module blhnsuicntrtctkn::vesting_ledger {
 
     public(package) fun claimable(
         entry: &AccountEntry,
+        initial_penalty: u64,
         current_epoch: u64,
         claim_period: u64,
     ): u64 {
-        let unlock_per_epoch = 10000000000 / claim_period;
-        let elapsed_epochs = current_epoch - entry.epoch;
-        let mut claimable_percentage = (elapsed_epochs + 1) * unlock_per_epoch;
-        if (claimable_percentage > 10000000000) {
-            claimable_percentage = 10000000000;
-        };
-        (entry.balance * claimable_percentage) / 10000000000
+        let elapsed_epochs = u64::min(current_epoch - entry.epoch, claim_period);
+        let scale: u128 = 10_000_000_000;
+        let scale_claim_period = scale * (claim_period as u128);
+        let penalty_factor_passed_time: u128 = (initial_penalty as u128) * ((claim_period as u128) - (elapsed_epochs as u128));
+        assert!(penalty_factor_passed_time <= scale_claim_period, 31337);
+        let numerator_claimable: u128 = scale_claim_period - penalty_factor_passed_time;
+        let claimable_u128: u128 = (entry.balance as u128) * numerator_claimable / scale_claim_period;
+        let claimable: u64 = claimable_u128 as u64;
+        claimable
     }
 
     public(package) fun claim_entry(
         entry: &mut AccountEntry,
+        claim_amount: u64,
+        initial_penalty: u64,
         current_epoch: u64,
-        period: u64,
-        amount: u64,
+        claim_period: u64,
     ): (u64, u64) {
-            let max_claimable = entry.claimable(current_epoch, period);
-
-            let to_claim = if (amount <= max_claimable) amount else max_claimable;
-
-            let proportional_penalty = (to_claim * (entry.balance - max_claimable)) / max_claimable;
-            entry.balance = entry.balance - to_claim - proportional_penalty;
-
-            (to_claim, proportional_penalty)
+        assert!(entry.balance <= 300000000 * 10_000_000_000, 31337);
+        assert!(initial_penalty <= 10_000_000_000, 31337);
+        let elapsed_epochs = u64::min(current_epoch - entry.epoch, claim_period);
+        assert!(elapsed_epochs <= 1800, 31337);
+        assert!(claim_period <= 1800, 31337);
+        let max_claimable = entry.claimable(initial_penalty, current_epoch, claim_period);
+        let claim_amount = u64::min(claim_amount, max_claimable);
+        let scale: u128 = 10_000_000_000;
+        let scale_claim_period = scale * (claim_period as u128);
+        let penalty_factor_passed_time: u128 = (initial_penalty as u128) * ((claim_period as u128) - (elapsed_epochs as u128));
+        let penalty = (claim_amount as u128 * scale_claim_period as u128) / ( scale_claim_period - penalty_factor_passed_time) - (claim_amount as u128);
+        entry.balance = entry.balance - claim_amount - (penalty as u64);
+        (claim_amount, penalty as u64)
     }
 
     public(package) fun set_vesting_period<T>(
@@ -261,15 +274,15 @@ module blhnsuicntrtctkn::vesting_ledger_tests {
         let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(PERIOD, INITIAL_PENALTY, &mut ctx);
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 0, &mut ctx);
         test_utils::assert_eq(ledger.available_balance(USER, 0), 100);
-        test_utils::assert_eq(ledger.available_balance(USER, 1), 200);
-        test_utils::assert_eq(ledger.available_balance(USER, 2), 300);
-        test_utils::assert_eq(ledger.available_balance(USER, 3), 400);
-        test_utils::assert_eq(ledger.available_balance(USER, 4), 500);
-        test_utils::assert_eq(ledger.available_balance(USER, 5), 600);
-        test_utils::assert_eq(ledger.available_balance(USER, 6), 700);
-        test_utils::assert_eq(ledger.available_balance(USER, 7), 800);
-        test_utils::assert_eq(ledger.available_balance(USER, 8), 900);
-        test_utils::assert_eq(ledger.available_balance(USER, 9), 1000);
+        test_utils::assert_eq(ledger.available_balance(USER, 1), 190);
+        test_utils::assert_eq(ledger.available_balance(USER, 2), 280);
+        test_utils::assert_eq(ledger.available_balance(USER, 3), 370);
+        test_utils::assert_eq(ledger.available_balance(USER, 4), 460);
+        test_utils::assert_eq(ledger.available_balance(USER, 5), 550);
+        test_utils::assert_eq(ledger.available_balance(USER, 6), 640);
+        test_utils::assert_eq(ledger.available_balance(USER, 7), 730);
+        test_utils::assert_eq(ledger.available_balance(USER, 8), 820);
+        test_utils::assert_eq(ledger.available_balance(USER, 9), 910);
         test_utils::assert_eq(ledger.available_balance(USER, 10), 1000);
         test_utils::destroy(ledger);
     }
@@ -292,32 +305,32 @@ module blhnsuicntrtctkn::vesting_ledger_tests {
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 0, &mut ctx);
         test_utils::assert_eq(ledger.available_balance(USER, 0), 1);
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 1, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 1), 3);
+        test_utils::assert_eq(ledger.available_balance(USER, 1), 2);
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 2, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 2), 6);
+        test_utils::assert_eq(ledger.available_balance(USER, 2), 4);
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 3, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 3), 10);
+        test_utils::assert_eq(ledger.available_balance(USER, 3), 7);
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 4, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 4), 15);
+        test_utils::assert_eq(ledger.available_balance(USER, 4), 11);
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 5, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 5), 21);
+        test_utils::assert_eq(ledger.available_balance(USER, 5), 16);
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 6, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 6), 28);
+        test_utils::assert_eq(ledger.available_balance(USER, 6), 22);
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 7, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 7), 36);
+        test_utils::assert_eq(ledger.available_balance(USER, 7), 29);
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 8, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 8), 45);
+        test_utils::assert_eq(ledger.available_balance(USER, 8), 37);
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(10, &mut ctx), 9, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 9), 55);
-        test_utils::assert_eq(ledger.available_balance(USER, 10), 64);
-        test_utils::assert_eq(ledger.available_balance(USER, 11), 72);
-        test_utils::assert_eq(ledger.available_balance(USER, 12), 79);
-        test_utils::assert_eq(ledger.available_balance(USER, 13), 85);
-        test_utils::assert_eq(ledger.available_balance(USER, 14), 90);
-        test_utils::assert_eq(ledger.available_balance(USER, 15), 94);
-        test_utils::assert_eq(ledger.available_balance(USER, 16), 97);
-        test_utils::assert_eq(ledger.available_balance(USER, 17), 99);
-        test_utils::assert_eq(ledger.available_balance(USER, 18), 100);
+        test_utils::assert_eq(ledger.available_balance(USER, 9), 46);
+        test_utils::assert_eq(ledger.available_balance(USER, 10), 55);
+        test_utils::assert_eq(ledger.available_balance(USER, 11), 64);
+        test_utils::assert_eq(ledger.available_balance(USER, 12), 72);
+        test_utils::assert_eq(ledger.available_balance(USER, 13), 79);
+        test_utils::assert_eq(ledger.available_balance(USER, 14), 85);
+        test_utils::assert_eq(ledger.available_balance(USER, 15), 90);
+        test_utils::assert_eq(ledger.available_balance(USER, 16), 94);
+        test_utils::assert_eq(ledger.available_balance(USER, 17), 97);
+        test_utils::assert_eq(ledger.available_balance(USER, 18), 99);
         test_utils::assert_eq(ledger.available_balance(USER, 19), 100);
         test_utils::destroy(ledger);
     }
@@ -441,30 +454,30 @@ module blhnsuicntrtctkn::vesting_ledger_tests {
         let mut ctx = tx_context::dummy();
         let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(3, INITIAL_PENALTY, &mut ctx);
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 0, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 0), 333);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 100);
 
-        let (locked, penalty) = ledger.claim(USER, 82, 0, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 0), 251);
-        test_utils::assert_eq(penalty.value(), 164);
+        let (locked, penalty) = ledger.claim(USER, 25, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 75);
+        test_utils::assert_eq(penalty.value(), 225);
         test_utils::destroy(locked);
         test_utils::destroy(penalty);
 
-        let (locked, penalty) = ledger.claim(USER, 82, 0, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 0), 169);
-        test_utils::assert_eq(penalty.value(), 164);
+        let (locked, penalty) = ledger.claim(USER, 25, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 50);
+        test_utils::assert_eq(penalty.value(), 225);
         test_utils::destroy(locked);
         test_utils::destroy(penalty);
 
-        let (locked, penalty) = ledger.claim(USER, 82, 0, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 0), 87);
-        test_utils::assert_eq(penalty.value(), 164);
+        let (locked, penalty) = ledger.claim(USER, 25, 0, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 0), 25);
+        test_utils::assert_eq(penalty.value(), 225);
         test_utils::destroy(locked);
         test_utils::destroy(penalty);
 
         // Still can claim all the remaining coins.
-        let (locked, penalty) = ledger.claim(USER, 87, 0, &mut ctx);
+        let (locked, penalty) = ledger.claim(USER, 25, 0, &mut ctx);
         test_utils::assert_eq(ledger.available_balance(USER, 0), 0);
-        test_utils::assert_eq(penalty.value(), 175);
+        test_utils::assert_eq(penalty.value(), 225);
         test_utils::destroy(locked);
         test_utils::destroy(penalty);
         test_utils::destroy(ledger);
@@ -478,15 +491,15 @@ module blhnsuicntrtctkn::vesting_ledger_tests {
         test_utils::assert_eq(ledger.available_balance(USER, 0), 100);
 
         // Now 40% of coins are available, because each epoch unlocks 10%.
-        test_utils::assert_eq(ledger.available_balance(USER, 3), 400);
+        test_utils::assert_eq(ledger.available_balance(USER, 3), 370);
 
         // Claiming 100 coins now would incur only 150 coins of penalty
         // (instead of 900) since the penalty is reduced accordingly to elapsed
         // epochs.
         let (locked, penalty) = ledger.claim(USER, 100, 3, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 3), 300);
+        test_utils::assert_eq(ledger.available_balance(USER, 3), 270);
         test_utils::assert_eq(locked.value(), 100);
-        test_utils::assert_eq(penalty.value(), 150);
+        test_utils::assert_eq(penalty.value(), 170);
         test_utils::destroy(locked);
         test_utils::destroy(penalty);
 
@@ -499,18 +512,17 @@ module blhnsuicntrtctkn::vesting_ledger_tests {
         let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(PERIOD, INITIAL_PENALTY, &mut ctx);
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 0, &mut ctx);
         test_utils::assert_eq(ledger.available_balance(USER, 0), 100);
-
-        test_utils::assert_eq(ledger.available_balance(USER, 1), 200);
-        test_utils::assert_eq(ledger.available_balance(USER, 2), 300);
-        test_utils::assert_eq(ledger.available_balance(USER, 3), 400);
-        test_utils::assert_eq(ledger.available_balance(USER, 4), 500);
-        test_utils::assert_eq(ledger.available_balance(USER, 5), 600);
-        test_utils::assert_eq(ledger.available_balance(USER, 6), 700);
-        test_utils::assert_eq(ledger.available_balance(USER, 7), 800);
-        test_utils::assert_eq(ledger.available_balance(USER, 8), 900);
-        test_utils::assert_eq(ledger.available_balance(USER, 9), 1000);
-        let (locked, penalty) = ledger.claim(USER, 1000, 9, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 9), 0);
+        test_utils::assert_eq(ledger.available_balance(USER, 1), 190);
+        test_utils::assert_eq(ledger.available_balance(USER, 2), 280);
+        test_utils::assert_eq(ledger.available_balance(USER, 3), 370);
+        test_utils::assert_eq(ledger.available_balance(USER, 4), 460);
+        test_utils::assert_eq(ledger.available_balance(USER, 5), 550);
+        test_utils::assert_eq(ledger.available_balance(USER, 6), 640);
+        test_utils::assert_eq(ledger.available_balance(USER, 7), 730);
+        test_utils::assert_eq(ledger.available_balance(USER, 8), 820);
+        test_utils::assert_eq(ledger.available_balance(USER, 9), 910);
+        let (locked, penalty) = ledger.claim(USER, 1000, 10, &mut ctx);
+        test_utils::assert_eq(ledger.available_balance(USER, 10), 0);
         test_utils::assert_eq(locked.value(), 1000);
         test_utils::assert_eq(penalty.value(), 0);
 
@@ -527,7 +539,7 @@ module blhnsuicntrtctkn::vesting_ledger_tests {
         test_utils::assert_eq(ledger.available_balance(USER, 0), 100);
 
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 1, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 1), 300);
+        test_utils::assert_eq(ledger.available_balance(USER, 1), 290);
 
         // Now it should be "unloked" to claim 20% of first 1000 coins and,
         // 10% of the second 1000 coins. So 300 coins in total.
@@ -537,9 +549,9 @@ module blhnsuicntrtctkn::vesting_ledger_tests {
         // only.
 
         let (locked, penalty) = ledger.claim(USER, 100, 1, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 1), 200);
+        test_utils::assert_eq(ledger.available_balance(USER, 1), 190);
         test_utils::assert_eq(locked.value(), 100);
-        test_utils::assert_eq(penalty.value(), 400);
+        test_utils::assert_eq(penalty.value(), 426);
 
         test_utils::destroy(locked);
         test_utils::destroy(penalty);
@@ -551,10 +563,10 @@ module blhnsuicntrtctkn::vesting_ledger_tests {
         let mut ctx = tx_context::dummy();
         let mut ledger = vesting_ledger::create<VESTING_LEDGER_TESTS>(PERIOD, INITIAL_PENALTY, &mut ctx);
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 0, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 0), 100);
+        test_utils::assert_eq(ledger.available_balance(USER, 1), 190);
 
         ledger.set_vesting_period(5);
-        test_utils::assert_eq(ledger.available_balance(USER, 0), 200);
+        test_utils::assert_eq(ledger.available_balance(USER, 1), 280);
 
         test_utils::destroy(ledger);
     }
@@ -567,18 +579,18 @@ module blhnsuicntrtctkn::vesting_ledger_tests {
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 1, &mut ctx);
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 2, &mut ctx);
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 3, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 3), 2500);
+        test_utils::assert_eq(ledger.available_balance(USER, 3), 1750);
         test_utils::assert_eq(ledger.account_history_len(USER), 4);
 
         // Now on each subsequent lock or deposit, on new epochs, the old one
         // are pruned and recorded as instant balance.
 
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 4, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 4), 3500);
+        test_utils::assert_eq(ledger.available_balance(USER, 4), 2750);
         test_utils::assert_eq(ledger.account_history_len(USER), 4);
 
         ledger.lock(USER, coin::mint_for_testing<VESTING_LEDGER_TESTS>(1000, &mut ctx), 5, &mut ctx);
-        test_utils::assert_eq(ledger.available_balance(USER, 5), 4500);
+        test_utils::assert_eq(ledger.available_balance(USER, 5), 3750);
         test_utils::assert_eq(ledger.account_history_len(USER), 4);
 
         test_utils::destroy(ledger);


### PR DESCRIPTION
We introduced a token-locking feature to encourage long-term commitment, boost demand, and stabilize prices. Locking tokens for a set period reduces immediate selling, limits supply, and prevents large-scale token dumps.

We added a new lock_batch function, similar to deposit_batch, that locks coins instead of depositing them. Tokens locked this way are not immediately accessible. Claiming them right away incurs a penalty, which encourages users to keep tokens locked. After a configurable period, tokens can be claimed without any penalty. All penalty fees go to the lockup pool.

The migration script also adds a new administrative object called VestingAdminCap. Its holder can adjust locking parameters, such as the lock duration and the initial penalty rate.